### PR TITLE
HSearch+ES/Wikipedia demo: Upgrade to Search 5.8.1, ORM 5.2.11

### DIFF
--- a/hibernate-search/hsearch-elasticsearch-wikipedia/pom.xml
+++ b/hibernate-search/hsearch-elasticsearch-wikipedia/pom.xml
@@ -25,8 +25,8 @@
 		<mapstruct.version>1.1.0.Final</mapstruct.version>
 		<apt.version>1.1.3</apt.version>
 		<!-- Override the version of Hibernate ORM in Spring Boot (5.1 or something as I'm writing this) -->
-		<hibernate.version>5.2.10.Final</hibernate.version>
-		<hibernate.search.version>5.8.0.Beta1</hibernate.search.version>
+		<hibernate.version>5.2.11.Final</hibernate.version>
+		<hibernate.search.version>5.8.1.Final</hibernate.search.version>
 	</properties>
 
 	<dependencies>

--- a/hibernate-search/hsearch-elasticsearch-wikipedia/src/main/resources/application.yaml
+++ b/hibernate-search/hsearch-elasticsearch-wikipedia/src/main/resources/application.yaml
@@ -31,6 +31,7 @@ spring.jackson:
   default-property-inclusion: NON_NULL
 
 logging.level:
-  org.hibernate.SQL: DEBUG
+  # Uncomment for extensive SQL logging
+  #org.hibernate.SQL: DEBUG
   org.hibernate.search.batchindexing: INFO
   org.hibernate.search.fulltext_query: DEBUG


### PR DESCRIPTION
I waited until we fixed and released [HSEARCH-2886](https://hibernate.atlassian.net/browse/HSEARCH-2886), because this demo was affected by the bug (it uses content from Wikipedia, with some articles containing a lot of exotic unicode characters).

Testing may prove a bit time consuming, since you need to initialize a database. Refer to the README if you wish to test, but otherwise I give you my word it works as intended :)