### PR TITLE
OCP-DEMO Add slots to server task deployment config

### DIFF
--- a/openshift/message-board/extra/message-server-task/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/openshift/message-board/extra/message-server-task/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -3,8 +3,8 @@
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
     <deployment>
         <dependencies>
-            <module name="org.infinispan.protostream" />
-            <module name="org.infinispan.remote-query.server" />
+            <module name="org.infinispan.protostream" slot="ispn-9.3" />
+            <module name="org.infinispan.remote-query.server" slot="ispn-9.3" />
         </dependencies>
     </deployment>
 </jboss-deployment-structure>

--- a/openshift/message-board/message-service/pom.xml
+++ b/openshift/message-board/message-service/pom.xml
@@ -126,6 +126,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.196</version>

--- a/openshift/message-board/message-service/src/test/java/org/hibernate/demo/message/post/it/MessageTaskIT.java
+++ b/openshift/message-board/message-service/src/test/java/org/hibernate/demo/message/post/it/MessageTaskIT.java
@@ -1,0 +1,42 @@
+package org.hibernate.demo.message.post.it;
+
+import java.io.File;
+
+import org.hibernate.demo.message.post.util.DeploymentUtil;
+import org.hibernate.demo.message.post.util.MavenUtils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+@RunWith(Arquillian.class)
+public class MessageTaskIT {
+
+	@Deployment(name = "wildfly")
+	@TargetsContainer("wildfly")
+	public static WebArchive doDeploy() {
+		return DeploymentUtil.create();
+	}
+
+	@Deployment(name = "infinispan", testable = false)
+	@TargetsContainer("infinispan")
+	public static JavaArchive getInfinispanDeployment() {
+		File file = Maven.resolver()
+			.resolve( "org.hibernate.demos.messageboard:message-server-task:jar:" + MavenUtils.getProperty("project.version") )
+			.withoutTransitivity().asSingleFile();
+
+		return ShrinkWrap.createFromZipFile( JavaArchive.class, file );
+	}
+
+	@Test
+	public void tryStartInfinispanRemoteWithTask() {
+		//TODO: implement test case
+	}
+}

--- a/openshift/message-board/message-service/src/test/java/org/hibernate/demo/message/post/util/MavenUtils.java
+++ b/openshift/message-board/message-service/src/test/java/org/hibernate/demo/message/post/util/MavenUtils.java
@@ -1,0 +1,27 @@
+
+package org.hibernate.demo.message.post.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class MavenUtils {
+
+	private static final String MAVEN_PROPERTIES_FILENAME = "maven.properties";
+
+	private static Properties getProperties() {
+		try ( InputStream inputStream = MavenUtils.class.getClassLoader().getResourceAsStream( MAVEN_PROPERTIES_FILENAME ) ) {
+			Properties mavenProperties = new Properties();
+			mavenProperties.load( inputStream );
+			return mavenProperties;
+		}
+		catch (IOException e) {
+			// not expected
+			throw new RuntimeException( e );
+		}
+	}
+
+	public static String getProperty(String propertyName) {
+		return getProperties().getProperty( propertyName );
+	}
+}

--- a/openshift/message-board/message-service/src/test/resources/maven.properties
+++ b/openshift/message-board/message-service/src/test/resources/maven.properties
@@ -1,0 +1,6 @@
+# Define here the Maven properties you want to make available through MavenUtil.getProperties().
+#
+# It would be nice to have these generated with something like properties-maven-plugin but
+# at the moment that doesn't copy system properties and tests don't run propertly in Eclipse.
+
+project.version=${project.version}

--- a/openshift/message-board/pom.xml
+++ b/openshift/message-board/pom.xml
@@ -19,10 +19,10 @@
     </properties>
 
     <modules>
+        <module>extra</module>
         <module>account-service</module>
         <module>message-service</module>
         <module>test-util</module>
-        <module>extra</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Infinispan server 9.3 uses now `ispn-9.3` as internal slot module.