### PR TITLE
Update jpa-cdi-testing to run on JDK 14

### DIFF
--- a/other/cdi-jpa-testing/pom.xml
+++ b/other/cdi-jpa-testing/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>14</maven.compiler.source>
+        <maven.compiler.target>14</maven.compiler.target>
 
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.org.hibernate>5.4.0.Final</version.org.hibernate>
@@ -27,7 +27,7 @@
         <version.jnpserver>5.0.3.GA</version.jnpserver>
         <version.jboss-transaction-api>1.1.1.Final</version.jboss-transaction-api>
         <version.log4j>1.2.17</version.log4j>
-        <version.weld>3.0.5.Final</version.weld>
+        <version.weld>3.1.3.Final</version.weld>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
@gunnarmorling asked if I could have a look at the `jpa-cdi-testing` project and open an PR to make it run on JDK 14. Here it is.

```
C:\JDK\Java14\bin\java.exe -Dmaven.multiModuleProjectDirectory=C:\Git\hibernate-demos\other\cdi-jpa-testing -  [...]
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------< org.hibernate.demos:jpa-cdi-testing >-----------------
[INFO] Building Demo for testing CDI + JPA + JTA under Java SE 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 

[...]


[INFO] --- maven-jar-plugin:3.0.2:jar (default-jar) @ jpa-cdi-testing ---
[INFO] Building jar: C:\Git\hibernate-demos\other\cdi-jpa-testing\target\jpa-cdi-testing-1.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.627 s

```

fixes #43