### PR TITLE
Migrate jpa-cdi-testing demo to Junit Jupiter

### DIFF
--- a/other/cdi-jpa-testing/pom.xml
+++ b/other/cdi-jpa-testing/pom.xml
@@ -50,9 +50,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>1.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -109,14 +116,14 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-junit4</artifactId>
-            <version>1.3.1.Final</version>
+            <artifactId>weld-junit5</artifactId>
+            <version>2.0.1.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.11.1</version>
+            <version>3.15.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/other/cdi-jpa-testing/src/test/java/org/hibernate/demos/jpacditesting/CdiJpaTest.java
+++ b/other/cdi-jpa-testing/src/test/java/org/hibernate/demos/jpacditesting/CdiJpaTest.java
@@ -4,35 +4,46 @@
  */
 package org.hibernate.demos.jpacditesting;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import org.hibernate.demos.jpacditesting.support.JtaEnvironment;
+import org.jboss.weld.junit5.auto.ActivateScopes;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.UUID;
-
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.TransactionalException;
 import javax.transaction.UserTransaction;
+import java.util.List;
+import java.util.UUID;
 
-import org.hibernate.demos.jpacditesting.support.JtaEnvironment;
-import org.jboss.weld.environment.se.Weld;
-import org.jboss.weld.junit4.WeldInitiator;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
+@EnableAutoWeld
+@AddPackages(JtaEnvironment.class)
+@ActivateScopes({RequestScoped.class, ApplicationScoped.class})
 public class CdiJpaTest {
 
-    @ClassRule
-    public static JtaEnvironment jtaEnvironment = new JtaEnvironment();
+    // Rewrite the @ClassRule as a @BeforeAll
 
-    @Rule
-    public WeldInitiator weld = WeldInitiator.from(new Weld())
-            .activate(RequestScoped.class)
-            .inject(this)
-            .build();
+    //@ClassRule
+    public static JtaEnvironment jtaEnvironment; //  = new JtaEnvironment();
+
+    @BeforeAll
+    public static void beforeAll() {
+        jtaEnvironment = new JtaEnvironment();
+    }
+
+
+//    @Rule
+//    public WeldInitiator weld = WeldInitiator.from(new Weld())
+//            .activate(RequestScoped.class)
+//            .inject(this)
+//            .build();
 
     // new Weld() above enables scanning of the classpath; alternatively, only the required beans can be listed explicitly:
 

--- a/other/cdi-jpa-testing/src/test/java/org/hibernate/demos/jpacditesting/SimpleCdiTest.java
+++ b/other/cdi-jpa-testing/src/test/java/org/hibernate/demos/jpacditesting/SimpleCdiTest.java
@@ -4,22 +4,15 @@
  */
 package org.hibernate.demos.jpacditesting;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Test;
 
-import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
-import org.jboss.weld.junit4.WeldInitiator;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@EnableAutoWeld
 public class SimpleCdiTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.from(GreetingService.class)
-        .activate(RequestScoped.class)
-        .inject(this)
-        .build();
 
     @Inject
     private GreetingService greeter;


### PR DESCRIPTION
I was trying to update the current (JDK 8) version of the `jpa-cdi-testing`-demo to use JUnit Jupiter instead of JUnit4.

I changed all (?) necessary dependencies and annotations but the tests in `CdiJpaTest` failes because Hibernate is unable to build a session (em is recieving a timeout).

Does anyone has an idea what I'm missing?


Note:

* Using the manual weld setup from the previous version doesn't change anything. So I think I have all classes activated
* Adding the package of `OberserverTestBean` via `@AddPackages` does not help.
* `SimpleCdiTest` works fine

Official Junit5-Weld documentation is this https://github.com/weld/weld-junit/blob/master/junit5/README.md

Test execution log:
[unableToBuildSession.txt](https://github.com/hibernate/hibernate-demos/files/4365600/unableToBuildSession.txt)