### PR TITLE
Upgrade docker-maven-plugin to 0.48.1

### DIFF
--- a/hibernate-search/hsearch-elasticsearch-wikipedia/pom.xml
+++ b/hibernate-search/hsearch-elasticsearch-wikipedia/pom.xml
@@ -24,14 +24,13 @@
 		<java.version>17</java.version>
 		<mapstruct.version>1.5.5.Final</mapstruct.version>
 		<apt.version>1.1.3</apt.version>
-		<docker-maven-plugin.version>0.34.1</docker-maven-plugin.version>
 		<!-- Override the version of Hibernate ORM in Spring Boot -->
 		<hibernate.version>6.4.4.Final</hibernate.version>
 		<!-- Override the version of Elasticsearch Rest Client in Spring Boot -->
 		<elasticsearch.version>8.12.2</elasticsearch.version>
 		<hibernate.search.version>7.1.0.Final</hibernate.search.version>
 
-		<docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+		<docker-maven-plugin.version>0.48.1</docker-maven-plugin.version>
 		<test.postgres.run.skip>true</test.postgres.run.skip>
 		<test.postgres.run.image.name>postgres</test.postgres.run.image.name>
 		<test.postgres.run.image.tag>13.1</test.postgres.run.image.tag>

--- a/hibernate-search/hsearch-with-elasticsearch/pom.xml
+++ b/hibernate-search/hsearch-with-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
 		<version.org.hibernate.search>6.2.5.Final</version.org.hibernate.search>
 		<version.org.hibernate.orm>5.6.15.Final</version.org.hibernate.orm>
 
-		<docker-maven-plugin.version>0.34.1</docker-maven-plugin.version>
+		<docker-maven-plugin.version>0.48.1</docker-maven-plugin.version>
 		<test.containers.run.skip>false</test.containers.run.skip>
 		<test.elasticsearch.run.skip>false</test.elasticsearch.run.skip>
 		<test.elasticsearch.run.image.name>elastic/elasticsearch</test.elasticsearch.run.image.name>


### PR DESCRIPTION
## Summary
- Remove duplicate `docker-maven-plugin.version` property in `hsearch-elasticsearch-wikipedia/pom.xml`
- Upgrade docker-maven-plugin from 0.34.1/0.43.4 to 0.48.1 across all hibernate-search demos

## Why
The `hsearch-elasticsearch-wikipedia` POM had two definitions of the `docker-maven-plugin.version` property (lines 27 and 34), which could cause confusion. The latest version (0.48.1) includes improvements for Docker wait configuration and better compatibility with recent Spring Boot versions.

## Test plan
- [x] Verified the build passes locally
- [ ] CI will verify compatibility across all environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)