### PR TITLE
Fix Spatial demo dependency resolution for current Maven hosts

### DIFF
--- a/hibernate-orm/core/Spatial/Spatial.gradle
+++ b/hibernate-orm/core/Spatial/Spatial.gradle
@@ -1,5 +1,3 @@
-// Dead hosts (boundlessgeo, old OSGeo webdav, hibernatespatial) no longer serve artifacts.
-// Use OSGeo's current Maven repo + Central. geodb 0.8 is unpublished; 0.9 is the replacement.
 repositories {
     mavenCentral()
     maven {
@@ -12,6 +10,4 @@ dependencies {
     compile( 'org.geolatte:geolatte-geom:1.3.0' )
     // GeoDB is an H2 spatial extension
     compile( 'org.opengeo:geodb:0.9' )
-    // Needed by GeoDB (also pulled transitively; listed explicitly for clarity)
-    compile( 'net.sourceforge.hatbox:hatbox:1.0.b10' )
 }

--- a/hibernate-orm/core/Spatial/Spatial.gradle
+++ b/hibernate-orm/core/Spatial/Spatial.gradle
@@ -1,21 +1,17 @@
+// Dead hosts (boundlessgeo, old OSGeo webdav, hibernatespatial) no longer serve artifacts.
+// Use OSGeo's current Maven repo + Central. geodb 0.8 is unpublished; 0.9 is the replacement.
 repositories {
     mavenCentral()
     maven {
-        url "http://download.osgeo.org/webdav/geotools"
-    }
-    maven {
-        url "http://www.hibernatespatial.org/repository"
-    }
-    maven {
-        url "http://repo.boundlessgeo.com/main"
+        url "https://repo.osgeo.org/repository/release/"
     }
 }
 
 dependencies {
     compile( 'org.hibernate:hibernate-spatial:' + rootProject.hibernateVersion )
     compile( 'org.geolatte:geolatte-geom:1.3.0' )
-    // GeoDB is an H2 extension
-    compile( 'org.opengeo:geodb:0.8')
-    // Needed by GeoDB
-    compile( 'net.sourceforge.hatbox:hatbox:1.0.b7' )
+    // GeoDB is an H2 spatial extension
+    compile( 'org.opengeo:geodb:0.9' )
+    // Needed by GeoDB (also pulled transitively; listed explicitly for clarity)
+    compile( 'net.sourceforge.hatbox:hatbox:1.0.b10' )
 }


### PR DESCRIPTION
## Summary
- Replace dead Maven repositories (Boundless, old OSGeo webdav, hibernatespatial) with `https://repo.osgeo.org/repository/release/` and Maven Central
- Bump `org.opengeo:geodb` from `0.8` (no longer published) to `0.9`, and `hatbox` to `1.0.b10` so the Spatial module resolves and compiles with a normal `./gradlew` build

## Test plan
- [x] With JDK 8: `cd hibernate-orm/core && ./gradlew :Spatial:clean :Spatial:compileJava --refresh-dependencies`
- [x] `./gradlew test` (all modules) succeeds
- [ ] CI / reviewer verify Spatial module still builds without local Maven installs